### PR TITLE
Add IE 10+ compatibility to supportsCustomEvent

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -1,7 +1,7 @@
 var dialogPolyfill = (function() {
 
   var supportCustomEvent = window.CustomEvent;
-  if (!supportCustomEvent) {
+  if (!supportCustomEvent || typeof supportCustomEvent == "object") {
     supportCustomEvent = function CustomEvent(event, x) {
       x = x || {};
       var ev = document.createEvent('CustomEvent');


### PR DESCRIPTION
Currently the supportsCustomEvent throws an exception in IE 10.

Adding a check for the type to ensure it is a function fixes this for IE 10.

Because while IE 10 supports new CustomEvent() with 'CustomEvent' only.
